### PR TITLE
Fix autohide

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -148,6 +148,8 @@ export default class FreeScrollbar extends React.Component {
         document.removeEventListener('mousemove', this.handleHandlerMouseMove);
         document.removeEventListener('mouseup', this.handleHandlerMouseUp);
         document.removeEventListener('readystatechange', this.handleReadyStateChange);
+        
+        clearTimeout(this.handlerHider);
     }
 
     componentDidUpdate() {


### PR DESCRIPTION
Fix `"Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the FreeScrollbar component."`

Due to un - `clearTimeout`